### PR TITLE
Never emit Ember global on ember versions that don't support it

### DIFF
--- a/lib/babel-options-util.js
+++ b/lib/babel-options-util.js
@@ -91,11 +91,9 @@ function _getDebugMacroPlugins(config, project) {
 
   if (_emberVersionRequiresModulesAPIPolyfill(project)) {
     useModulesVersion = false;
-  } else if (addonOptions.compileModules === false) {
+  } else if (addonOptions.compileModules === false && _emberVersionSupportsEmberGlobal(project)) {
     // we have to use the global form when not compiling modules, because it is often used
     // in the context of an `app.import` where there is no wrapped in an AMD module
-    //
-    // However, you can opt out of this behavior by explicitly specifying `disableDebugTooling`
     useModulesVersion = disableDebugTooling === false;
   } else {
     useModulesVersion = true;
@@ -141,6 +139,16 @@ function _emberVersionRequiresModulesAPIPolyfill(project) {
   return result;
 }
 
+function _emberVersionSupportsEmberGlobal(project) {
+  let checker = new VersionChecker(project).for("ember-source", "npm");
+  if (!checker.exists()) {
+    return true;
+  }
+  let result = checker.lt("4.0.0-alpha.1");
+
+  return result;
+}
+
 function _emberDataVersionRequiresPackagesPolyfill(project) {
   let checker = new VersionChecker(project);
   let dep = checker.for("ember-data");
@@ -165,7 +173,7 @@ function _getEmberModulesAPIPolyfill(config, parent, project) {
 
   if (_emberVersionRequiresModulesAPIPolyfill(project)) {
     useModulesVersion = false;
-  } else if (addonOptions.compileModules === false) {
+  } else if (addonOptions.compileModules === false && _emberVersionSupportsEmberGlobal(project)) {
     // we have to use the global form when not compiling modules, because it is often used
     // in the context of an `app.import` where there is no wrapped in an AMD module
     //


### PR DESCRIPTION
For bad historic reasons, if you disable AMD compilation with `compileModules: false`, it opts you into the using the `Ember` global via modulesAPIPolyfill and debug-macros. This is a problem because we absolutely *do* want to disable AMD compilation as we move toward [strict-es-modules](https://github.com/emberjs/rfcs/pull/938), but the Ember global has been gone since 4.0.

It's possible to work around the modulesAPIPolyfill issue by explicitly turning the polyfill off. But it's impossible to work around the debug-macros problem, because we don't want to turn them off, we want to keep them on but tell them to use imports instead of globals.

In both cases, it's a bad default that emits code that could never possibly work. This PR makes Ember 4.0 the hard cutoff, after which we will never emit globals, because they don't work there anyway.