### PR TITLE
delete compileModules from preset-env options

### DIFF
--- a/lib/babel-options-util.js
+++ b/lib/babel-options-util.js
@@ -26,6 +26,7 @@ function _getPresetEnv(config, project) {
   delete presetOptions.generatorOpts;
   delete presetOptions.plugins;
   delete presetOptions.postTransformPlugins;
+  delete presetOptions.compileModules;
 
   return [require.resolve("@babel/preset-env"), presetOptions];
 }


### PR DESCRIPTION
I can't trace exactly what combination of my dependencies is leading to this scenario but without this change, `compileModules` is getting passed through to preset-env and causing issues. With this change I am able to move forward with my refactor / upgrades.